### PR TITLE
Fix `ap` for Nothing

### DIFF
--- a/lib/maybe.js
+++ b/lib/maybe.js
@@ -201,9 +201,7 @@ Maybe.prototype.of = Maybe.of
  */
 Maybe.prototype.ap = unimplemented
 
-Nothing.prototype.ap = function(b) {
-  return b
-}
+Nothing.prototype.ap = noop
 
 Just.prototype.ap = function(b) {
   return b.map(this.value)


### PR DESCRIPTION
This was breaking the interchange law.

``` javascript
> Maybe.Nothing().ap(Maybe.of(3))
{ value: 3 }
> Maybe.of(function(f) { return f(3); }).ap(Maybe.Nothing())
{}
```
