### PR TITLE
Update docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Released under the [MIT licence](https://github.com/folktale/data.maybe/blob/mas
 [Make]: http://www.gnu.org/software/make/
 [Node.js]: http://nodejs.org/
 [es5-shim]: https://github.com/kriskowal/es5-shim
-[docs]: http://folktale.github.io/data.maybe
+[docs]: http://docs.folktalejs.org/en/latest/api/data/maybe/
 <!-- [release: https://github.com/folktale/data.maybe/releases/download/v$VERSION/data.maybe-$VERSION.tar.gz] -->
 [release]: https://github.com/folktale/data.maybe/releases/download/v1.2.0/data.maybe-1.2.0.tar.gz
 <!-- [/release] -->


### PR DESCRIPTION
I think it's currently pointing to old documentation.

It might be better to link directly to http://docs.folktalejs.org/en/latest/api/data/maybe/Maybe.html