### PR TITLE
Make Nothing.prototype.ap a noop

### DIFF
--- a/lib/maybe.js
+++ b/lib/maybe.js
@@ -201,9 +201,7 @@ Maybe.prototype.of = Maybe.of
  */
 Maybe.prototype.ap = unimplemented
 
-Nothing.prototype.ap = function(b) {
-  return b
-}
+Nothing.prototype.ap = noop
 
 Just.prototype.ap = function(b) {
   return b.map(this.value)

--- a/test/specs/maybe.ls
+++ b/test/specs/maybe.ls
@@ -49,7 +49,7 @@ module.exports = spec 'Maybe', (o, spec) ->
   spec 'Nothings' (o) ->
     o 'ap should propagate' do
        for-all(Any).satisfy (a) ->
-         Nothing!.ap(Just a).is-equal Just(a)
+         Nothing!.ap(Just a).is-nothing 
        .as-test!
     o 'map should propagate' ->
        ok Nothing!.map(id).is-nothing


### PR DESCRIPTION
This makes `Nothing` work _how I think_ it should as demonstrated in #9. I'm not confident enough with FP and what not to be certain.