### PR TITLE
Maybe.orElse is now gauranteed to return a Monad

### DIFF
--- a/lib/maybe.js
+++ b/lib/maybe.js
@@ -333,7 +333,12 @@ Just.prototype.getOrElse = function(_) {
 Maybe.prototype.orElse = unimplemented
 
 Nothing.prototype.orElse = function(f) {
-  return f()
+  const fVal = f()
+  if (fVal && typeof fVal === "object" && ("value" in fVal)) {
+    return fVal
+  } else {
+    return Maybe.fromNullable(fVal)
+  }
 }
 
 Just.prototype.orElse = function(_) {

--- a/test/specs/maybe.ls
+++ b/test/specs/maybe.ls
@@ -68,9 +68,9 @@ module.exports = spec 'Maybe', (o, spec) ->
        for-all(Any).satisfy (a) ->
          Nothing!.get-or-else(a) is a
        .as-test!
-    o 'or-else should call the thunk' do
+    o 'or-else should return a monad of thunk return value' do
        for-all(Any).satisfy (a) ->
-         Nothing!.or-else(-> a) is a
+         Nothing!.or-else(-> a).is-equal Maybe.fromNullable(a)
        .as-test!
     o 'cata should invoke the Nothing function' do
        for-all(Any, Any).satisfy (a, b) ->


### PR DESCRIPTION
This is necessary to align with the documentation.  Otherwise passing in a function to orElse that doesn't return a monad will result in orElse returning a value.
