### PR TITLE
lifting Just() values using .fromNullable() instead of .of()

### DIFF
--- a/lib/maybe.js
+++ b/lib/maybe.js
@@ -223,7 +223,7 @@ Maybe.prototype.map   = unimplemented
 Nothing.prototype.map = noop
 
 Just.prototype.map = function(f) {
-  return this.of(f(this.value))
+  return this.fromNullable(f(this.value))
 }
 
 


### PR DESCRIPTION
Assuming I have a student JSON:
`
const student = {
  firstName: 'Anup',
  lastName: 'Vasudeva'
};
`
And if I fetch it's `address` property via `.map()`, it should return `Maybe.Nothing` instead of `Maybe.Just`.
`
  const address = Maybe.fromNullable(student)
    .map(R.prop('address'))
    .map(R.prop('country'))
    .getOrElse('Country does not exist');
`
The current implementation of `.map()`, would result in a `TypeError`, since `.map()` lifts the value using `.of()` instead of `.fromNullable()`